### PR TITLE
Change PeekMessage timeout in uniqueinstance.pas

### DIFF
--- a/uniqueinstance/uniqueinstance.pas
+++ b/uniqueinstance/uniqueinstance.pas
@@ -100,7 +100,7 @@ end;
 {$ifdef PollIPCMessage}
 procedure TUniqueInstance.CheckMessage(Sender: TObject);
 begin
-  FIPCServer.PeekMessage(1, True);
+  FIPCServer.PeekMessage(0, True);
 end;
 {$endif}
 


### PR DESCRIPTION
Using ProcessExplorer, I see that with a timeout of 1ms cpu load of an idle program is around 0.30/0.40
Changing it to 0 the load is 0.01
The performance difference is probably not really relevant, but it's nicer anyway.
Under linux 64 I don't see a difference either way, but that's probably because I'm running it on real hardware (win32 is a virtual machine).