### PR TITLE
Use TGtkDeviceContext instead of TGtk2DeviceContext

### DIFF
--- a/cairo/lcl/include/gtk2/cairolcl.inc
+++ b/cairo/lcl/include/gtk2/cairolcl.inc
@@ -7,7 +7,7 @@ end;
 
 function CreateSurfaceFromDC(DC: HDC): Pcairo_surface_t;
 var
-  DeviceContext: TGtk2DeviceContext absolute DC;
+  DeviceContext: TGtkDeviceContext absolute DC;
   Width, Height: Integer;
   Visual: PGdkVisual;
 begin


### PR DESCRIPTION
Fix this compilation error (Lazarus 2.2.4, Linux):

```
cairolcl.inc(10,18) Error: Identifier not found "TGtk2DeviceContext"
```