### PR TITLE
Append missing unit LCLPlatformDef in two Cairo demos

### DIFF
--- a/cairo/demos/cairo_snippets/gui/main.pas
+++ b/cairo/demos/cairo_snippets/gui/main.pas
@@ -33,7 +33,7 @@ var
 implementation
 
 uses
-  Cairo, CairoLCL, snippets, InterfaceBase;
+  Cairo, CairoLCL, snippets, InterfaceBase, LCLPlatformDef;
 
 { TFormMain }
 

--- a/cairo/demos/clock/fmain.pas
+++ b/cairo/demos/clock/fmain.pas
@@ -35,7 +35,7 @@ var
 implementation
 
 uses
-  Cairo, InterfaceBase;
+  Cairo, InterfaceBase, LCLPlatformDef;
 
 const
   m_radius = 0.42;


### PR DESCRIPTION
Otherwise the demos don't compile:

```

Compile Project, Target: cairo_snippets_gui.exe: Exit code 1, Errors: 1, Warnings: 1
main.pas(46,27) Error: Identifier not found "LCLPlatformDirNames"
```

```
Compile Project, Target: cairoclock.exe: Exit code 1, Errors: 1
fmain.pas(141,31) Error: Identifier not found "LCLPlatformDirNames"
```