### PR TITLE
Use fpg_interface (Windows)

### DIFF
--- a/cairo/fpgui/cairo_gdi.inc
+++ b/cairo/fpgui/cairo_gdi.inc
@@ -1,5 +1,5 @@
 uses
-  CairoWin32, fpg_gdi;
+  CairoWin32, fpg_gdi, fpg_interface;
 
 type
 


### PR DESCRIPTION
Fix this compilation error:

```
cairo_gdi.inc(6,44) Error: Identifier not found "TfpgCanvasImpl"
```